### PR TITLE
prevent black bars appearing at the top and bottom of the watsonsdktest app

### DIFF
--- a/watsonsdktest/watsonsdktest-Info.plist
+++ b/watsonsdktest/watsonsdktest-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>


### PR DESCRIPTION
Set the Launch Screen File to be the Main_iPhone storyboard. Without having launch screen set in ios9/xcode 7 black bars appear at the top and bottom of the app.
