### PR TITLE
allow ssl connections to the speech service from the watsonsdktest app

### DIFF
--- a/watsonsdktest/watsonsdktest-Info.plist
+++ b/watsonsdktest/watsonsdktest-Info.plist
@@ -47,5 +47,19 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>watsonplatform.net</key>
+            <dict>
+                <!--Include to allow subdomains-->
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <key>NSTemporaryExceptionRequiresForwardSecrecy</key>
+                <false/>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This provides a temporary fix for the sample app to get around more stringent certificate
checking of ssl certs in ios9
