### PR TITLE
Use AVAudioSession.requestRecordPermission before starting to recognize

### DIFF
--- a/watsonsdk.xcodeproj/project.pbxproj
+++ b/watsonsdk.xcodeproj/project.pbxproj
@@ -1293,6 +1293,7 @@
 					"$(SRCROOT)/speexenc",
 					"$(SRCROOT)/ogg",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/watsonsdk/lib",
@@ -1319,6 +1320,7 @@
 					"$(SRCROOT)/speexenc",
 					"$(SRCROOT)/ogg",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/watsonsdk/lib",

--- a/watsonsdk/AuthConfiguration.m
+++ b/watsonsdk/AuthConfiguration.m
@@ -58,7 +58,16 @@
     } else if(self.basicAuthPassword && self.basicAuthUsername) {
         NSString *authStr = [NSString stringWithFormat:@"%@:%@", self.basicAuthUsername,self.basicAuthPassword];
         NSData *authData = [authStr dataUsingEncoding:NSUTF8StringEncoding];
-        NSString *authValue = [NSString stringWithFormat:@"Basic %@", [authData base64EncodedStringWithOptions:0]];
+        NSString *base64;
+        if ([authData respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
+            base64 = [authData base64EncodedStringWithOptions:0];
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            base64 = [authData base64Encoding];
+#pragma clang diagnostic pop
+        }
+        NSString *authValue = [NSString stringWithFormat:@"Basic %@", base64];
         [headers setObject:authValue forKey:@"Authorization"];
     }
     

--- a/watsonsdk/stt/SpeechToText.m
+++ b/watsonsdk/stt/SpeechToText.m
@@ -146,23 +146,29 @@ id oggRef;
 
     if (!isNewRecordingAllowed) {
         // don't allow a new recording to be allowed until this transaction has completed
+        // NSError *recordError = [SpeechUtility raiseErrorWithMessage:@"A voice query is already in progress"];
+        // self.recognizeCallback(nil, recordError);
         return;
     }
     isNewRecordingAllowed = NO;
 
-    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-        if (granted) {
-            // Permission granted
-            [self startRecordingAudio];
-        } else {
-            // Permission denied
-            isNewRecordingAllowed = YES;
-            NSError *recordError = [SpeechUtility raiseErrorWithMessage:@"Record permission denied"];
-            self.recognizeCallback(nil, recordError);
-        }
-    }];
-    // NSError *recordError = [SpeechUtility raiseErrorWithMessage:@"A voice query is already in progress"];
-    // self.recognizeCallback(nil, recordError);
+    if ([[AVAudioSession sharedInstance] respondsToSelector:@selector(requestRecordPermission:)]) {
+        // iOS 7.x and above. Needs to ask permission
+        [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+            if (granted) {
+                // Permission granted
+                [self startRecordingAudio];
+            } else {
+                // Permission denied
+                isNewRecordingAllowed = YES;
+                NSError *recordError = [SpeechUtility raiseErrorWithMessage:@"Record permission denied"];
+                self.recognizeCallback(nil, recordError);
+            }
+        }];
+    } else {
+        // iOS 6.x: Permission is always granted.
+        [self startRecordingAudio];
+    }
 }
 
 /**

--- a/watsonsdktest-objective-c/STTViewController.m
+++ b/watsonsdktest-objective-c/STTViewController.m
@@ -109,6 +109,7 @@
         else {
             NSLog(@"received error from the SDK %@",[err description]);
             [stt endRecognize];
+            [self presentAlertWithTitle:@"Error" message:err.localizedDescription];
         }
     } dataHandler:^(NSData* data) {
         NSLog(@"sent out %lu bytes", (unsigned long)[data length]);
@@ -180,6 +181,16 @@
     }
     
     return _pickerView;
+}
+
+#pragma mark -
+
+- (void)presentAlertWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        [alert dismissViewControllerAnimated:YES completion:nil];
+    }]]
+    [self presentViewController:alert animated:true completion:nil];
 }
 
 #pragma mark - UIPickerViewDataSource Methods

--- a/watsonsdktest-objective-c/watsonsdktest-Info.plist
+++ b/watsonsdktest-objective-c/watsonsdktest-Info.plist
@@ -60,5 +60,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Watson Speech to Text recognition</string>
 </dict>
 </plist>

--- a/watsonsdktest-swift/Info.plist
+++ b/watsonsdktest-swift/Info.plist
@@ -56,5 +56,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Watson Speech to Text recognition</string>
 </dict>
 </plist>

--- a/watsonsdktest-swift/SwiftSTTViewController.swift
+++ b/watsonsdktest-swift/SwiftSTTViewController.swift
@@ -69,6 +69,7 @@ class SwiftSTTViewController: UIViewController, UITextFieldDelegate, UIPickerVie
             else{
                 print("Error from the SDK: %@", error.localizedDescription)
                 self.sttInstance?.endRecognize()
+                self.presentAlertWithTitle("Error", message:error.localizedDescription);
             }
         })
         
@@ -161,6 +162,14 @@ class SwiftSTTViewController: UIViewController, UITextFieldDelegate, UIPickerVie
         }
     }
     
+    func presentAlertWithTitle(title: String, message:String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .Alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .Default) { (alertAction) in
+            alert.dismissViewControllerAnimated(true, completion: nil);
+        })
+        self.presentViewController(alert, animated: true, completion: nil)
+    }
+
     // UIPickerView delegate methods
     func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int{
         return 1


### PR DESCRIPTION
This solves #34 

Code is slightly different from https://github.com/mihui/speech-ios-sdk/commit/a5bd6aedf5af5466977d0b0e0f07b15f02ebb324 because it does not cache `isPermissionGranted`. It is not cached because the user could change permissions between recording sessions and then this flag would be invalid.

`[[AVAudioSession sharedInstance] requestRecordPermission:...` does not _really_ request access when it has been granted already so it is ok to call it always.

I am not handling iOS6 since `IPHONEOS_DEPLOYMENT_TARGET` is 8.0 now. @mihui if you need ios6 I guess is doable, although it became 8 a bit ago (See https://github.com/watson-developer-cloud/speech-ios-sdk/issues/28)
