### PR TITLE
Fix crash when attempting to created NSError with nil reasonMessage

### DIFF
--- a/watsonsdk/SpeechUtility.m
+++ b/watsonsdk/SpeechUtility.m
@@ -123,6 +123,19 @@
  *  @return customized error
  */
 + (NSError *)raiseErrorWithCode:(NSInteger)code message:(NSString *)errorMessage reason:(NSString *)reasonMessage suggestion:(NSString *)suggestionMessage{
+    // Ideally errorMessage and reasonMessage and suggestionMessage should never be nil. It sometimes happens :(
+    if (!errorMessage) {
+        NSLog(@"%s no errorMessage provided. Falling back to default.", __PRETTY_FUNCTION__);
+        errorMessage = @"Unexpected error";
+    }
+    if (!reasonMessage) {
+        NSLog(@"%s no reasonMessage provided. Falling back to default.", __PRETTY_FUNCTION__);
+        reasonMessage = @"Unknown reason";
+    }
+    if (!suggestionMessage) {
+        NSLog(@"%s no suggestionMessage provided. Falling back to default.", __PRETTY_FUNCTION__);
+        reasonMessage = @"";
+    }
     NSDictionary *userInfo = @{
                                NSLocalizedDescriptionKey: errorMessage,
                                NSLocalizedFailureReasonErrorKey: reasonMessage,


### PR DESCRIPTION
SocketRocket might return `_errorCode 0` and `_errorReason nil` when socket was closed before data could be sent. `+[SpeechUtility raiseErrorWithCode:message:reason:suggestion:]` will crash in that case.

```
NSString *errorMessage = @"Websocket closed before data could be sent";
NSError *error = [SpeechUtility raiseErrorWithCode:code message:errorMessage reason:reason suggestion:@"Try reconnecting"];
[self webSocket:webSocket didFailWithError:error];
```

How to reproduce:

call `[stt stopRecordingAudio]` on `UIApplicationWillResignActiveNotification`. The first time the user will be requested for his/her permission and the app will resign active, even before socket could get any data,  causing the crash.
