### PR TITLE
Better build script (build universal static libraries too)

### DIFF
--- a/scripts/makeUniversalFrameworks.sh
+++ b/scripts/makeUniversalFrameworks.sh
@@ -1,0 +1,115 @@
+#! /bin/bash
+
+set -e
+
+# The following conditionals come from
+# https://github.com/kstenerud/iOS-Universal-Framework
+
+if [[ "$SDK_NAME" =~ ([A-Za-z]+) ]]
+then
+    SF_SDK_PLATFORM=${BASH_REMATCH[1]}
+else
+    echo "Could not find platform name from SDK_NAME: $SDK_NAME"
+    exit 1
+fi
+
+if [[ "$SDK_NAME" =~ ([0-9]+.*$) ]]
+then
+    SF_SDK_VERSION=${BASH_REMATCH[1]}
+else
+    echo "Could not find sdk version from SDK_NAME: $SDK_NAME"
+    exit 1
+fi
+
+if [[ "$SF_SDK_PLATFORM" = "iphoneos" ]]
+then
+    SF_OTHER_PLATFORM=iphonesimulator
+else
+    SF_OTHER_PLATFORM=iphoneos
+fi
+
+if [[ "$BUILT_PRODUCTS_DIR" =~ (.*)$SF_SDK_PLATFORM$ ]]
+then
+    SF_OTHER_BUILT_PRODUCTS_DIR="${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}"
+else
+    echo "Could not find platform name from build products directory: $BUILT_PRODUCTS_DIR"
+    exit 1
+fi
+
+# Create directory for universal builds
+UNIVERSAL_BUILD_PRODUCTS_DIR=$(dirname "${BUILT_PRODUCTS_DIR}")"/${CONFIGURATION}-universal/"
+mkdir -p "${UNIVERSAL_BUILD_PRODUCTS_DIR}"
+
+# Build the other platform
+xcodebuild -project "${PROJECT_FILE_PATH}" \
+    -target "${TARGET_NAME}" \
+    -configuration "${CONFIGURATION}" \
+    -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} \
+    BUILD_DIR="${BUILD_DIR}" OBJROOT="${OBJROOT}" BUILD_ROOT="${BUILD_ROOT}" SYMROOT="${SYMROOT}" $ACTION
+
+# Universal Dynamic framework
+# ===========================
+
+# Replicate what Xcode defines
+SF_EXECUTABLE_NAME="WatsonSDK"
+SF_WRAPPER_NAME="WatsonSDK.framework"
+SF_EXECUTABLE_PATH="${SF_WRAPPER_NAME}/${SF_EXECUTABLE_NAME}"
+
+# Copy iphoneos platform into the universal directory (must be iphoneos so Info.plist is correct)
+IPHONEOS_BUILD_PRODUCTS_DIR=$(dirname "${BUILT_PRODUCTS_DIR}")"/${CONFIGURATION}-iphoneos/"
+rm -rf "${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}"
+cp -R "${IPHONEOS_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}" "${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}"
+
+# Make the framework universal
+lipo -create "${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}" "${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}" \
+    -output "${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}"
+
+# Create a zip of the framework and add it to the project root
+cd "${UNIVERSAL_BUILD_PRODUCTS_DIR}"
+zip -r "${SRCROOT}/${SF_WRAPPER_NAME}.zip" "${SF_WRAPPER_NAME}"
+
+# Universal Static library
+# ========================
+
+SF_LIB_EXECUTABLE_PATH="libwatsonsdk.a"
+
+# Make static library universal
+xcodebuild -project "${PROJECT_FILE_PATH}" \
+    -target "${TARGET_NAME}" \
+    -configuration "${CONFIGURATION}" \
+    -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} \
+    BUILD_DIR="${BUILD_DIR}" OBJROOT="${OBJROOT}" BUILD_ROOT="${BUILD_ROOT}" SYMROOT="${SYMROOT}" $ACTION
+
+
+# Build the other platform
+lipo -create "${BUILT_PRODUCTS_DIR}/${SF_LIB_EXECUTABLE_PATH}" "${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_LIB_EXECUTABLE_PATH}" \
+    -output "${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_LIB_EXECUTABLE_PATH}"
+
+# Copy headers
+rm -rf "${UNIVERSAL_BUILD_PRODUCTS_DIR}/watsonsdkHeaders"
+cp -R "${BUILT_PRODUCTS_DIR}/watsonsdkHeaders" "${UNIVERSAL_BUILD_PRODUCTS_DIR}/watsonsdkHeaders"
+
+# Universal Static Framework (framework for old iOS6)
+# ===================================================
+
+# Build a simple (non versioned) static framework
+# watsonsdk.framework/
+# ├── Headers/
+# ├── Resources/
+# ├── Info.plist
+# └── watsonsdk
+STATIC_FRAMEWORK="${UNIVERSAL_BUILD_PRODUCTS_DIR}/staticFramework/watsonsdk.framework"
+rm -rf ${STATIC_FRAMEWORK}
+mkdir -p ${STATIC_FRAMEWORK}
+mkdir -p "${STATIC_FRAMEWORK}/Headers"
+mkdir -p "${STATIC_FRAMEWORK}/Resources"
+cp "${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_LIB_EXECUTABLE_PATH}" "${STATIC_FRAMEWORK}/watsonsdk"
+cp -R "${UNIVERSAL_BUILD_PRODUCTS_DIR}/WatsonSDK.framework/Headers" "${STATIC_FRAMEWORK}"
+cp "${UNIVERSAL_BUILD_PRODUCTS_DIR}/WatsonSDK.framework/Info.plist" "${STATIC_FRAMEWORK}"
+
+# Success!
+
+if [ $1 == "--open" ]
+then
+    open "${UNIVERSAL_BUILD_PRODUCTS_DIR}"
+fi

--- a/watsonsdk.xcodeproj/project.pbxproj
+++ b/watsonsdk.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		4FC4334E1D0EFBEA00ECEFD3 /* SRHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BCAD82D1CE6BF1200BE3B5F /* SRHash.h */; };
 		4FC4334F1D0EFC2A00ECEFD3 /* WatsonSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FC433161D0EE7AA00ECEFD3 /* WatsonSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FC433501D0EFC4400ECEFD3 /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BA060401CE6D9320018CA5B /* libicucore.tbd */; };
+		4FF8BBCA1D337B810019E618 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11A66DB1756098E00385896 /* AudioToolbox.framework */; };
 		7EFE11E41B71D07D00EF10BF /* AuthConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EFE11E21B71D07D00EF10BF /* AuthConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7EFE11E51B71D07D00EF10BF /* AuthConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFE11E31B71D07D00EF10BF /* AuthConfiguration.m */; };
 		9B1BCEE31CF69D440076FE2D /* TTSCustomWord.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B1BCEE11CF69D440076FE2D /* TTSCustomWord.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -309,6 +310,7 @@
 				4FC433401D0EFA8B00ECEFD3 /* Security.framework in Frameworks */,
 				4FC433431D0EFAB000ECEFD3 /* libogg.a in Frameworks */,
 				4FC433421D0EFAAC00ECEFD3 /* libopus.a in Frameworks */,
+				4FF8BBCA1D337B810019E618 /* AudioToolbox.framework in Frameworks */,
 				4FC4333F1D0EFA8000ECEFD3 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/watsonsdk.xcodeproj/project.pbxproj
+++ b/watsonsdk.xcodeproj/project.pbxproj
@@ -7,17 +7,18 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		C11A64891754D6AB00385896 /* Framework */ = {
+		C11A64891754D6AB00385896 /* Frameworks */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = C11A648A1754D6AB00385896 /* Build configuration list for PBXAggregateTarget "Framework" */;
+			buildConfigurationList = C11A648A1754D6AB00385896 /* Build configuration list for PBXAggregateTarget "Frameworks" */;
 			buildPhases = (
 				C11A648F1754D6DA00385896 /* ShellScript */,
 			);
 			dependencies = (
+				4FF8BBC91D3365280019E618 /* PBXTargetDependency */,
 				4FC433521D0F9AB200ECEFD3 /* PBXTargetDependency */,
 				C11A64A21754DA2D00385896 /* PBXTargetDependency */,
 			);
-			name = Framework;
+			name = Frameworks;
 			productName = Framework;
 		};
 /* End PBXAggregateTarget section */
@@ -167,6 +168,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4FC433131D0EE7AA00ECEFD3;
 			remoteInfo = WatsonSDK;
+		};
+		4FF8BBC81D3365280019E618 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C11A64531754D0E600385896 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C11A645A1754D0E600385896;
+			remoteInfo = watsonsdk;
 		};
 		C11A64A11754DA2D00385896 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -751,7 +759,6 @@
 				C11A64581754D0E600385896 /* Frameworks */,
 				C11A64591754D0E600385896 /* CopyFiles */,
 				C11A64861754D17900385896 /* Headers */,
-				C11A64881754D5F900385896 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -830,7 +837,7 @@
 			projectRoot = "";
 			targets = (
 				C11A645A1754D0E600385896 /* watsonsdk */,
-				C11A64891754D6AB00385896 /* Framework */,
+				C11A64891754D6AB00385896 /* Frameworks */,
 				C11A64931754D98700385896 /* watsonResources */,
 				C165429A191A0D8500905DCC /* OC Sample */,
 				9BF43ECE1CEAC81900EC0185 /* Swift Sample */,
@@ -882,19 +889,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		C11A64881754D5F900385896 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Please build \"Framework\" target to update WatsonSDK.framework.zip file\n# Below code is disabled since we have:\n# - \"WatsonSDK\" target which creates a dynamic framework\n# - \"Framework\" target which uses \"WatsonSDK\" target to create an universal version.\nexit 0\nset -e\n\nmkdir -p \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/A/Headers\"\n\n# Link the \"Current\" version to \"A\"\n/bin/ln -sfh A \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/Current\"\n/bin/ln -sfh Versions/Current/Headers \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Headers\"\n/bin/ln -sfh \"Versions/Current/${PRODUCT_NAME}\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/${PRODUCT_NAME}\"\n\n# The -a ensures that the headers maintain the source modification date so that we don't constantly\n# cause propagating rebuilds of files that import these headers.\n/bin/cp -a \"${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}/\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/A/Headers\"\necho \"${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}/\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/\" > ~/watsonsdklocation.txt\n\n# create a zip of the framework and add it to the project root\ncd ${BUILT_PRODUCTS_DIR}\nzip -r ${SRCROOT}/${PRODUCT_NAME}.framework.zip ${PRODUCT_NAME}.framework\n\n# [Rob] we need to copy the other headers keeping their folder structure\n#echo 'SRCROOT:'${SRCROOT}\n#cd ${SRCROOT}/watsonsdk\n\n# I have to move up a directory due to my layout.\n# echo 'Copying Headers into Framework..'\n#for H in `find ./ -name \"*.h\"`;  do\n#echo ${H}\n#ditto ${H} ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework/Versions/A/Headers/${H}\n#done\n";
-		};
 		C11A648F1754D6DA00385896 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -906,7 +900,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\nset +u\n\n# Avoid recursively calling this script.\nif [[ $SF_MASTER_SCRIPT_RUNNING ]]\nthen\nexit 0\nfi\nset -u\nexport SF_MASTER_SCRIPT_RUNNING=1\n\n# Replicate what Xcode defines\nSF_EXECUTABLE_NAME=\"WatsonSDK\"\nSF_WRAPPER_NAME=\"WatsonSDK.framework\"\nSF_EXECUTABLE_PATH=\"${SF_WRAPPER_NAME}/${SF_EXECUTABLE_NAME}\"\n\n\n# The following conditionals come from\n# https://github.com/kstenerud/iOS-Universal-Framework\n\nif [[ \"$SDK_NAME\" =~ ([A-Za-z]+) ]]\nthen\nSF_SDK_PLATFORM=${BASH_REMATCH[1]}\nelse\necho \"Could not find platform name from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\nif [[ \"$SDK_NAME\" =~ ([0-9]+.*$) ]]\nthen\nSF_SDK_VERSION=${BASH_REMATCH[1]}\nelse\necho \"Could not find sdk version from SDK_NAME: $SDK_NAME\"\nexit 1\nfi\n\nif [[ \"$SF_SDK_PLATFORM\" = \"iphoneos\" ]]\nthen\nSF_OTHER_PLATFORM=iphonesimulator\nelse\nSF_OTHER_PLATFORM=iphoneos\nfi\n\nif [[ \"$BUILT_PRODUCTS_DIR\" =~ (.*)$SF_SDK_PLATFORM$ ]]\nthen\nSF_OTHER_BUILT_PRODUCTS_DIR=\"${BASH_REMATCH[1]}${SF_OTHER_PLATFORM}\"\nelse\necho \"Could not find platform name from build products directory: $BUILT_PRODUCTS_DIR\"\nexit 1\nfi\n\n# Build the other platform.\nxcodebuild -project \"${PROJECT_FILE_PATH}\" -target \"${TARGET_NAME}\" -configuration \"${CONFIGURATION}\" -sdk ${SF_OTHER_PLATFORM}${SF_SDK_VERSION} BUILD_DIR=\"${BUILD_DIR}\" OBJROOT=\"${OBJROOT}\" BUILD_ROOT=\"${BUILD_ROOT}\" SYMROOT=\"${SYMROOT}\" $ACTION\n\n# Create directory for universal builds\nUNIVERSAL_BUILD_PRODUCTS_DIR=$(dirname \"${BUILT_PRODUCTS_DIR}\")\"/${CONFIGURATION}-universal/\"\nmkdir -p \"${UNIVERSAL_BUILD_PRODUCTS_DIR}\"\n\n# Copy iphoneos platform into the universal directory (must be iphoneos so Info.plist is correct)\nIPHONEOS_BUILD_PRODUCTS_DIR=$(dirname \"${BUILT_PRODUCTS_DIR}\")\"/${CONFIGURATION}-iphoneos/\"\nrm -rf \"${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\"\ncp -R \"${IPHONEOS_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\" \"${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_WRAPPER_NAME}\"\n\n# Make the framework universal\nlipo -create \"${BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" \"${SF_OTHER_BUILT_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\" -output \"${UNIVERSAL_BUILD_PRODUCTS_DIR}/${SF_EXECUTABLE_PATH}\"\n\n# create a zip of the framework and add it to the project root\ncd \"${UNIVERSAL_BUILD_PRODUCTS_DIR}\"\nzip -r \"${SRCROOT}/${SF_WRAPPER_NAME}.zip\" \"${SF_WRAPPER_NAME}\"\n\n#open \"${SRCROOT}\"\n#open \"${UNIVERSAL_BUILD_PRODUCTS_DIR}\"\n\necho done\n";
+			shellScript = "set -e\nset +u\n\n# Avoid recursively calling this script.\nif [[ $SF_MASTER_SCRIPT_RUNNING ]]\nthen\nexit 0\nfi\nset -u\nexport SF_MASTER_SCRIPT_RUNNING=1\n\n# Pass `--open` flag to open build directory after succcess\n\"${PROJECT_DIR}/scripts/makeUniversalFrameworks.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1003,6 +997,11 @@
 			isa = PBXTargetDependency;
 			target = 4FC433131D0EE7AA00ECEFD3 /* WatsonSDK */;
 			targetProxy = 4FC433511D0F9AB200ECEFD3 /* PBXContainerItemProxy */;
+		};
+		4FF8BBC91D3365280019E618 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C11A645A1754D0E600385896 /* watsonsdk */;
+			targetProxy = 4FF8BBC81D3365280019E618 /* PBXContainerItemProxy */;
 		};
 		C11A64A21754DA2D00385896 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1506,7 +1505,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C11A648A1754D6AB00385896 /* Build configuration list for PBXAggregateTarget "Framework" */ = {
+		C11A648A1754D6AB00385896 /* Build configuration list for PBXAggregateTarget "Frameworks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C11A648B1754D6AB00385896 /* Debug */,


### PR DESCRIPTION
- Moved the shell script that was inside the project (in the segregate target) to its own file to be able to track its changes more easily.
- Added code to generate the universal version of the static library and the static framework for iOS6 compatibility since some projects might be targeting iOS6 still.  
  Segregate target outputs in `${PRODUCTS_DIR}` in universal directory was:
  - WatsonSDK.framework (universal iOS8 and above)
  
  Now will be:
  - WatsonSDK.framework (universal, iOS8 and above, same as before)
  - libwatsonsdk.a (universal, iOS6 and above)
  - watsonHeaders/ 
  - staticFramework/watsonsdk.framework (universal, iOS6 and above)

<hr />

@mihui I think you will be glad to the static framework again :]

PS: Not doing this by default but you can pass `--open` option to the script to open finder so grabbing the binary is a bit easier.
<img src="https://cloud.githubusercontent.com/assets/111651/16826460/7c5c3b52-49b8-11e6-8772-0f857966ff60.png" width="400">
